### PR TITLE
Add compliant release build yaml

### DIFF
--- a/.ci/releaseBuild.yml
+++ b/.ci/releaseBuild.yml
@@ -1,0 +1,166 @@
+# The name of the build that will be seen in mscodehub
+name: CompatPowerShellget-Release-$(Build.BuildId)
+# how is the build triggered
+# since this is a release build, no trigger as it's a manual release
+trigger: none
+
+pr:
+  branches:
+    include:
+    - master
+
+# variables to set in the build environment
+variables:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  POWERSHELL_TELEMETRY_OPTOUT: 1
+
+# since this build relies on templates, we need access to those
+# This needs a service connection in the build to work
+# the *name* of the service connection must be the same as the endpoint
+resources:
+  repositories:
+  - repository: ComplianceRepo
+    type: github
+    endpoint: ComplianceGHRepo
+    name: PowerShell/compliance
+    # this can be any branch of your choosing
+    ref: master
+
+# the stages in this build. There are 2
+# the assumption for script analyzer is that test is done as part of
+# CI so we needn't do it here
+stages:
+- stage: Build
+  displayName: Build
+  pool:
+    name: Package ES CodeHub Lab E
+  jobs:
+  - job: Build_Job
+    displayName: Build Microsoft.PowerShell.CompatPowerShellGet
+    # note the variable reference to ESRP.
+    # this must be created in Project -> Pipelines -> Library -> VariableGroups
+    # where it describes the link to the SigningServer
+    variables:
+    - group: ESRP
+    steps:
+    - checkout: self
+
+    # because CompatPowerShellGet is a script, we can skip the build step
+
+    # these are setting vso variables which will be persisted between stages
+    - pwsh: |
+        $signSrcPath = "$(Build.SourcesDirectory)/src"
+        # Set signing src path variable
+        $vstsCommandString = "vso[task.setvariable variable=signSrcPath]${signSrcPath}"
+        Write-Host "sending " + $vstsCommandString
+        Write-Host "##$vstsCommandString"
+
+        $signOutPath = "$(Build.SourcesDirectory)/CompatPowerShellGet/signed"
+        $null = New-Item -ItemType Directory -Path $signOutPath
+        # Set signing out path variable
+        $vstsCommandString = "vso[task.setvariable variable=signOutPath]${signOutPath}"
+        Write-Host "sending " + $vstsCommandString
+        Write-Host "##$vstsCommandString"
+
+        # Set path variable for guardian codesign validation
+        $vstsCommandString = "vso[task.setvariable variable=GDN_CODESIGN_TARGETDIRECTORY]${signOutPath}"
+        Write-Host "sending " + $vstsCommandString
+        Write-Host "##$vstsCommandString"
+
+        # Get version and create a variable
+        $moduleData = Import-PowerShellDataFile "$(Build.SourcesDirectory)/CompatPowerShellGet/src/PSScriptAnalyzer.psd1"
+        $moduleVersion = $moduleData.ModuleVersion
+        $vstsCommandString = "vso[task.setvariable variable=moduleVersion]${moduleVersion}"
+        Write-Host "sending " + $vstsCommandString
+        Write-Host "##$vstsCommandString"
+
+
+      displayName: Setup variables for signing
+
+    # checkout the Compliance repository so it can be used to do the actual signing
+    - checkout: ComplianceRepo
+
+    # this the MS authored step  This cert covers MS autored items
+    # note that the buildOutputPath (where we get the files to sign)
+    # is the same as the signOutputPath in the previous step
+    # at the end of this step we will have all the files signed that should be
+    # signOutPath is the location which contains the files we will use to make the module
+    - template: EsrpSign.yml@ComplianceRepo
+      parameters:
+        # the folder which contains the binaries to sign
+        buildOutputPath: $(signSrcPath)
+        # the location to put the signed output
+        signOutputPath: $(signOutPath)
+        # the certificate ID to use
+        certificateId: "CP-230012"
+        # use minimatch because we need to exclude the NewtonSoft assembly
+        useMinimatch: true
+        # the file pattern to use - newtonSoft is excluded
+        pattern: |
+          **\*.psd1
+          **\*.psm1
+
+    # now create the nupkg which we will use to publish the module
+    # to the powershell gallery (not part of this yaml)
+    #- pwsh: |
+    #    Set-Location "$(Build.SourcesDirectory)/OSS_Microsoft_PSSA"
+    #    ./build -BuildNupkg -signed
+    #  displayName: Create nupkg for publishing
+
+    # finally publish the parts of the build which will be used in the next stages
+    # if it's not published, the subsequent stages will not be able to access it.
+    # This is the build directory (it contains all of the dll/pdb files)
+    - publish: "$(Build.SourcesDirectory)/CompatPowerShellGet"
+      artifact: build
+      displayName: publish build directory
+
+      # export the nupkg only which will be used in the release pipeline
+    - publish: "$(signOutPath)/CompatPowerShellGet.$(moduleVersion).nupkg"
+      artifact: nupkg
+      displayName: Publish module nupkg
+
+# Now on to the compliance stage
+- stage: compliance
+  displayName: Compliance
+  dependsOn: Build
+  jobs:
+  - job: Compliance_Job
+    pool:
+      name: Package ES CodeHub Lab E
+    steps:
+    - checkout: self
+    - checkout: ComplianceRepo
+    - download: current
+      artifact: build
+
+    # use the templates in the compliance repo
+    # no assemblies, you should use script-module-compliance template
+    - template: script-module-compliance.yml@ComplianceRepo
+      parameters:
+        # component-governance - the path to sources
+        sourceScanPath: '$(Build.SourcesDirectory)/CompatPowerShellGet'
+        # binskim - this isn't recursive, so you need the path to the assemblies
+        # analyzeTarget: '$(Pipeline.Workspace)\build\bin\PSV7Release\netcoreapp3.1\*.dll'
+        # credscan - scan the repo for credentials
+        # you can suppress some files with this.
+        # suppressionsFile: '$(Build.SourcesDirectory)/OSS_Microsoft_PSSA/tools/ReleaseBuild/CredScan.Suppressions.json'
+        # TermCheck
+        optionsRulesDBPath: ''
+        optionsFTPath: ''
+        # tsa-upload
+        # the compliance scanning must be uploaded, which you need to request
+        codeBaseName: 'PSSA_202004'
+        # selections
+        APIScan: false # set to false when not using Windows APIs.
+
+#- template: template/publish.yml
+#  parameters:
+#    stageName: AzArtifactsFeed
+#    environmentName:
+#    feedCredential:
+
+#- template: template/publish.yml
+#  parameters:
+#    stageName: NuGet
+#    environmentName: PSMarkdownRenderNuGetApproval
+#    feedCredential: NugetOrgPush

--- a/.ci/releaseBuild.yml
+++ b/.ci/releaseBuild.yml
@@ -46,16 +46,20 @@ stages:
     - checkout: self
 
     # because CompatPowerShellGet is a script, we can skip the build step
+    - pwsh: |
+        dir env:
+      displayName: Capture environment
 
     # these are setting vso variables which will be persisted between stages
     - pwsh: |
-        $signSrcPath = "$(Build.SourcesDirectory)/src"
+        $signSrcPath = "$(Build.SourcesDirectory)/CompatPowerShellGet/src"
+        dir
         # Set signing src path variable
         $vstsCommandString = "vso[task.setvariable variable=signSrcPath]${signSrcPath}"
         Write-Host "sending " + $vstsCommandString
         Write-Host "##$vstsCommandString"
 
-        $signOutPath = "$(Build.SourcesDirectory)/CompatPowerShellGet/signed"
+        $signOutPath = "$(Build.SourcesDirectory)/OSS_Microsoft_CompatPowerShellGet/signed/CompatPowerShellGet"
         $null = New-Item -ItemType Directory -Path $signOutPath
         # Set signing out path variable
         $vstsCommandString = "vso[task.setvariable variable=signOutPath]${signOutPath}"
@@ -68,13 +72,11 @@ stages:
         Write-Host "##$vstsCommandString"
 
         # Get version and create a variable
-        $moduleData = Import-PowerShellDataFile "$(Build.SourcesDirectory)/CompatPowerShellGet/src/PSScriptAnalyzer.psd1"
+        $moduleData = Import-PowerShellDataFile "$(Build.SourcesDirectory)/CompatPowerShellGet/src/CompatPowerShellGet.psd1"
         $moduleVersion = $moduleData.ModuleVersion
         $vstsCommandString = "vso[task.setvariable variable=moduleVersion]${moduleVersion}"
         Write-Host "sending " + $vstsCommandString
         Write-Host "##$vstsCommandString"
-
-
       displayName: Setup variables for signing
 
     # checkout the Compliance repository so it can be used to do the actual signing
@@ -100,24 +102,12 @@ stages:
           **\*.psd1
           **\*.psm1
 
-    # now create the nupkg which we will use to publish the module
-    # to the powershell gallery (not part of this yaml)
-    #- pwsh: |
-    #    Set-Location "$(Build.SourcesDirectory)/OSS_Microsoft_PSSA"
-    #    ./build -BuildNupkg -signed
-    #  displayName: Create nupkg for publishing
-
     # finally publish the parts of the build which will be used in the next stages
     # if it's not published, the subsequent stages will not be able to access it.
     # This is the build directory (it contains all of the dll/pdb files)
     - publish: "$(Build.SourcesDirectory)/CompatPowerShellGet"
       artifact: build
       displayName: publish build directory
-
-      # export the nupkg only which will be used in the release pipeline
-    #- publish: "$(signOutPath)/CompatPowerShellGet.$(moduleVersion).nupkg"
-    #  artifact: nupkg
-    #  displayName: Publish module nupkg
 
 # Now on to the compliance stage
 - stage: compliance
@@ -149,18 +139,6 @@ stages:
         optionsFTPath: ''
         # tsa-upload
         # the compliance scanning must be uploaded, which you need to request
-        codeBaseName: 'PSSA_202004'
+        codeBaseName: 'CompatPowerShellGet_20200201'
         # selections
         APIScan: false # set to false when not using Windows APIs.
-
-#- template: template/publish.yml
-#  parameters:
-#    stageName: AzArtifactsFeed
-#    environmentName:
-#    feedCredential:
-
-#- template: template/publish.yml
-#  parameters:
-#    stageName: NuGet
-#    environmentName: PSMarkdownRenderNuGetApproval
-#    feedCredential: NugetOrgPush

--- a/.ci/releaseBuild.yml
+++ b/.ci/releaseBuild.yml
@@ -27,7 +27,7 @@ resources:
     ref: master
 
 # the stages in this build. There are 2
-# the assumption for script analyzer is that test is done as part of
+# the assumption for is that test is done as part of
 # CI so we needn't do it here
 stages:
 - stage: Build
@@ -44,11 +44,6 @@ stages:
     - group: ESRP
     steps:
     - checkout: self
-
-    # because CompatPowerShellGet is a script, we can skip the build step
-    - pwsh: |
-        dir env:
-      displayName: Capture environment
 
     # these are setting vso variables which will be persisted between stages
     - pwsh: |
@@ -82,7 +77,7 @@ stages:
     # checkout the Compliance repository so it can be used to do the actual signing
     - checkout: ComplianceRepo
 
-    # this the MS authored step  This cert covers MS autored items
+    # this the MS authored step  This cert covers MS authored items
     # note that the buildOutputPath (where we get the files to sign)
     # is the same as the signOutputPath in the previous step
     # at the end of this step we will have all the files signed that should be
@@ -93,18 +88,14 @@ stages:
         buildOutputPath: $(signSrcPath)
         # the location to put the signed output
         signOutputPath: $(signOutPath)
-        # the certificate ID to use
+        # the certificate ID to use (Authenticode)
         certificateId: "CP-230012"
-        # use minimatch because we need to exclude the NewtonSoft assembly
-        useMinimatch: true
-        # the file pattern to use - newtonSoft is excluded
         pattern: |
           **\*.psd1
           **\*.psm1
 
     # finally publish the parts of the build which will be used in the next stages
     # if it's not published, the subsequent stages will not be able to access it.
-    # This is the build directory (it contains all of the dll/pdb files)
     - publish: "$(Build.SourcesDirectory)/OSS_Microsoft_CompatPowerShellGet"
       artifact: build
       displayName: publish build directory
@@ -129,11 +120,6 @@ stages:
       parameters:
         # component-governance - the path to sources
         sourceScanPath: '$(Build.SourcesDirectory)/CompatPowerShellGet'
-        # binskim - this isn't recursive, so you need the path to the assemblies
-        # analyzeTarget: '$(Pipeline.Workspace)\build\bin\PSV7Release\netcoreapp3.1\*.dll'
-        # credscan - scan the repo for credentials
-        # you can suppress some files with this.
-        # suppressionsFile: '$(Build.SourcesDirectory)/OSS_Microsoft_PSSA/tools/ReleaseBuild/CredScan.Suppressions.json'
         # TermCheck
         optionsRulesDBPath: ''
         optionsFTPath: ''

--- a/.ci/releaseBuild.yml
+++ b/.ci/releaseBuild.yml
@@ -105,7 +105,7 @@ stages:
     # finally publish the parts of the build which will be used in the next stages
     # if it's not published, the subsequent stages will not be able to access it.
     # This is the build directory (it contains all of the dll/pdb files)
-    - publish: "$(Build.SourcesDirectory)/CompatPowerShellGet"
+    - publish: "$(Build.SourcesDirectory)/OSS_Microsoft_CompatPowerShellGet"
       artifact: build
       displayName: publish build directory
 

--- a/.ci/releaseBuild.yml
+++ b/.ci/releaseBuild.yml
@@ -115,9 +115,9 @@ stages:
       displayName: publish build directory
 
       # export the nupkg only which will be used in the release pipeline
-    - publish: "$(signOutPath)/CompatPowerShellGet.$(moduleVersion).nupkg"
-      artifact: nupkg
-      displayName: Publish module nupkg
+    #- publish: "$(signOutPath)/CompatPowerShellGet.$(moduleVersion).nupkg"
+    #  artifact: nupkg
+    #  displayName: Publish module nupkg
 
 # Now on to the compliance stage
 - stage: compliance


### PR DESCRIPTION
Update build pipeline to use 'releaseBuild.yml' instead of Azure DevOps UI. The build yaml uses the PowerShell Compliance repository to build a compliant release that uses ESRP for code-signing.